### PR TITLE
dt: update bootargs to boot from mmc

### DIFF
--- a/arch/mips/jz4780/dts/ci20.dts
+++ b/arch/mips/jz4780/dts/ci20.dts
@@ -30,7 +30,7 @@
 	compatible = "img,ci20";
 
 	chosen {
-		bootargs = "console=ttyS0,115200 clk_ignore_unused";
+		bootargs = "console=ttyS0,115200 clk_ignore_unused root=/dev/mmcblk0p1 rootwait";
 	};
 
 	memory {


### PR DESCRIPTION
3.16 doesn't take bootargs from u-boot. But from dt.

Patch adds root=/dev/mmcblk0p1 rootwait to ci20.dts to boot from mmc

Signed-off-by: Zubair Lutfullah Kakakhel Zubair.Kakakhel@imgtec.com
