### PR TITLE
dt: jz4780: Removed redundant line from ci20's device tree file.

### DIFF
--- a/arch/mips/boot/dts/ci20.dts
+++ b/arch/mips/boot/dts/ci20.dts
@@ -165,7 +165,6 @@
 
 	dm9000@6 {
 		compatible = "davicom,dm9000";
-		davicom,no-eeprom;
 
 		reg = <6 0x0 1   /* addr */
 		       6 0x2 1>; /* data */


### PR DESCRIPTION
Trying to boot the kernel with compatible="davicom,no-eeprom"; doesn't work,
so remove the unneeded line to prevent confusion.
