### PR TITLE
dmaengine: jz4780: Fix jz4780_dma_prep_dma_cyclic prototype

### DIFF
--- a/drivers/dma/dma-jz4780.c
+++ b/drivers/dma/dma-jz4780.c
@@ -333,7 +333,7 @@ static struct dma_async_tx_descriptor *jz4780_dma_prep_slave_sg(
 static struct dma_async_tx_descriptor *jz4780_dma_prep_dma_cyclic(
 	struct dma_chan *chan, dma_addr_t buf_addr, size_t buf_len,
 	size_t period_len, enum dma_transfer_direction direction,
-	unsigned long flags, void *context)
+	unsigned long flags)
 {
 	struct jz4780_dma_chan *jzchan = to_jz4780_dma_chan(chan);
 	struct jz4780_dma_desc *desc;


### PR DESCRIPTION
The DMA engine prep_dma_cyclic function no longer takes a context
argument, remove it. This fixes a build warning.

Signed-off-by: Alex Smith alex.smith@imgtec.com
