### PR TITLE
DT: Add support for spi-gpio to JZ4780's DT

### DIFF
--- a/arch/mips/boot/dts/jz4780.dtsi
+++ b/arch/mips/boot/dts/jz4780.dtsi
@@ -384,6 +384,25 @@
 			};
 		};
 
+		spi_gpio {
+			compatible = "spi-gpio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			num-chipselects = <2>;
+
+			gpio-miso = <&gpe 14 0>;
+			gpio-sck = <&gpe 15 0>;
+			gpio-mosi = <&gpe 17 0>;
+			cs-gpios = <&gpe 16 0
+					&gpe 18 0>;
+
+			spidev@0 {
+				compatible = "spidev";
+				reg = <0>;
+				spi-max-frequency = <1000000>;
+			};
+		};
+
 		uart0: serial@10030000 {
 			compatible = "ingenic,jz4780-uart";
 			reg = <0x10030000 0x100>;


### PR DESCRIPTION
A SPI driver that uses the JZ4780's SPI hardware isn't available, so using
a bit banging GPIO driver will work for now. Once the SPI driver is completed,
it will use the same pins as the spi-gpio driver.

I've tested this crudely using [py-spidev](https://github.com/doceme/py-spidev), as can be seen below:

```
root@ci20:~# python
Python 2.7.3 (default, Mar 14 2014, 14:08:41) 
[GCC 4.6.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import spidev
>>> spi = spidev.SpiDev()
>>> spi.open(32766, 0)
>>> spi.xfer([1, 2, 3])
[0, 0, 0]
>>> spi.readbytes(10)
[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
>>> # Connecting MISO to 3.3v
... 
>>> spi.readbytes(10)
[255, 255, 255, 255, 255, 255, 255, 255, 255, 255]
>>> 
```

NOTE: Loading the spidev driver quite consistently (90% of the time) causing kernel panics. Below is a trace from such a kernel panic:

```
[    6.120000] brcmfmac_sdio mmc1:0001:2: no default pinctrl state
[    6.130000] ------------[ cut here ]------------
[    6.130000] WARNING: CPU: 0 PID: 13 at drivers/mmc/core/sdio_ops.c:134 mmc_io_rw_extended+0x384/0x3a8()
[    6.130000] CPU: 0 PID: 13 Comm: kworker/u2:1 Not tainted 3.18.3+ #199
[    6.130000] Workqueue: kmmcd mmc_rescan
[    6.130000] Stack : 00000002 00000000 8076c3f8 8bc73a80 8041f100 00000086 807adcec 00000000
[    6.130000]    8be21200 8be212f8 00000001 805e0424 8076c3f8 8004950c 8bc74cf0 00000000
[    6.130000]    8079bf34 8bc83964 8bc83964 805e0424 8076c3f8 80046a7c 00000000 808342d2
[    6.130000]    00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[    6.130000]    636d6d6b 00000064 00000000 00000000 00000000 00000000 8bd04d00 8bc47900
[    6.130000]    ...
[    6.130000] Call Trace:
[    6.130000] [<80018f5c>] show_stack+0x64/0x7c
[    6.130000] [<8002d310>] warn_slowpath_common+0x7c/0xac
[    6.130000] [<8002d3f8>] warn_slowpath_null+0x18/0x30
[    6.130000] [<8041f100>] mmc_io_rw_extended+0x384/0x3a8
[    6.130000] [<80420068>] sdio_io_rw_ext_helper+0xd8/0x208
[    6.130000] [<80420a98>] sdio_readl+0x40/0xa4
[    6.130000] [<803bca5c>] brcmf_sdiod_request_data+0x12c/0x1f0
[    6.130000] [<803bcbb4>] brcmf_sdiod_regrw_helper+0x94/0x1a4
[    6.130000] [<803bdb60>] brcmf_sdiod_regrl+0x64/0x6c
[    6.130000] [<803b73c8>] brcmf_sdio_buscore_read32+0x20/0x78
[    6.130000] [<803ab2d0>] brcmf_chip_attach+0xc0/0x8fc
[    6.130000] [<803b9590>] brcmf_sdio_probe+0x210/0xa54
[    6.130000] [<803bd2bc>] brcmf_ops_sdio_probe+0x2ec/0x3ac
[    6.130000] [<8034e6ec>] driver_probe_device.part.12+0xf0/0x358
[    6.130000] [<8034cfc0>] bus_for_each_drv+0x68/0xb0
[    6.130000] [<8034ec7c>] device_attach+0xb0/0xd4
[    6.130000] [<8034d2a0>] bus_probe_device+0xa0/0xdc
[    6.130000] [<8034aacc>] device_add+0x440/0x590
[    6.130000] [<8041f634>] sdio_add_func+0x40/0x70
[    6.130000] [<8041ea0c>] mmc_attach_sdio+0x268/0x35c
[    6.130000] [<80415e78>] mmc_rescan+0x428/0x4bc
[    6.130000] [<80043b98>] process_one_work+0x14c/0x38c
[    6.130000] [<80043f34>] worker_thread+0x15c/0x59c
[    6.130000] [<800493b4>] kthread+0xd0/0xe8
[    6.130000] [<80013b8c>] ret_from_kernel_thread+0x14/0x1c
[    6.130000] 
[    6.130000] ---[ end trace 0888e27679ed5f64 ]---
[    6.130000] Kernel bug detected[#1]:
[    6.130000] CPU: 0 PID: 13 Comm: kworker/u2:1 Tainted: G        W      3.18.3+ #199
[    6.130000] Workqueue: kmmcd mmc_rescan
[    6.130000] task: 8bc74a78 ti: 8bc82000 task.ti: 8bc82000
[    6.130000] $ 0   : 00000000 80018f5c 00000001 80830000
[    6.130000] $ 4   : 8be212f8 00000000 00000000 00000002
[    6.130000] $ 8   : 00000010 8029f280 00000001 20343666
[    6.130000] $12   : 00000000 00000001 00000000 807d0000
[    6.130000] $16   : 00000002 00000000 fffffffc 807f9290
[    6.130000] $20   : 8bd72000 00000000 00000000 000002f8
[    6.130000] $24   : 00000000 8042785c                  
[    6.130000] $28   : 8bc82000 8bc83910 81190420 8001d930
[    6.130000] Hi    : 00000000
[    6.130000] Lo    : 00000000
[    6.130000] epc   : 80027fe4 r4k_dma_cache_inv+0xc/0xd4
[    6.130000]     Tainted: G        W     
[    6.130000] ra    : 8001d930 mips_dma_map_sg+0xc8/0x25c
[    6.130000] Status: 10000403 KERNEL EXL IE 
[    6.130000] Cause : 00800034
[    6.130000] PrId  : 3ee1024f (Ingenic JZRISC)
[    6.130000] Process kworker/u2:1 (pid: 13, threadinfo=8bc82000, task=8bc74a78, tls=00000000)
[    6.130000] Stack : 000003e0 00000001 ffffffff 807d0000 00000000 81220b38 00000002 8001d930
[    6.130000]    00000004 807d0000 00000000 00000000 00000000 00000000 00000409 00000081
[    6.130000]    fffffffc 8bc83a38 8bc83a6c 00000000 8bca8810 00000081 8be65240 8042761c
[    6.130000]    808342ba 00000024 00000081 00000000 00000000 8be65284 ffff8f80 8006d490
[    6.130000]    8041f100 00000086 807adcec 00000000 00000001 8be212f8 00000001 805e0424
[    6.130000]    ...
[    6.130000] Call Trace:
[    6.130000] [<80027fe4>] r4k_dma_cache_inv+0xc/0xd4
[    6.130000] [<8001d930>] mips_dma_map_sg+0xc8/0x25c
[    6.130000] [<8042761c>] jz47xx_mmc_send_command+0x194/0x3d4
[    6.130000] [<80412bf4>] __mmc_start_req+0x6c/0xa0
[    6.130000] [<804138e8>] mmc_wait_for_req+0x1c/0x38
[    6.130000] [<8041efac>] mmc_io_rw_extended+0x230/0x3a8
[    6.130000] [<80420068>] sdio_io_rw_ext_helper+0xd8/0x208
[    6.130000] [<80420a98>] sdio_readl+0x40/0xa4
[    6.130000] [<803bca5c>] brcmf_sdiod_request_data+0x12c/0x1f0
[    6.130000] [<803bcbb4>] brcmf_sdiod_regrw_helper+0x94/0x1a4
[    6.130000] [<803bdb60>] brcmf_sdiod_regrl+0x64/0x6c
[    6.130000] [<803b73c8>] brcmf_sdio_buscore_read32+0x20/0x78
[    6.130000] [<803ab2d0>] brcmf_chip_attach+0xc0/0x8fc
[    6.130000] [<803b9590>] brcmf_sdio_probe+0x210/0xa54
[    6.130000] [<803bd2bc>] brcmf_ops_sdio_probe+0x2ec/0x3ac
[    6.130000] [<8034e6ec>] driver_probe_device.part.12+0xf0/0x358
[    6.130000] [<8034cfc0>] bus_for_each_drv+0x68/0xb0
[    6.130000] [<8034ec7c>] device_attach+0xb0/0xd4
[    6.130000] [<8034d2a0>] bus_probe_device+0xa0/0xdc
[    6.130000] [<8034aacc>] device_add+0x440/0x590
[    6.130000] [<8041f634>] sdio_add_func+0x40/0x70
[    6.130000] [<8041ea0c>] mmc_attach_sdio+0x268/0x35c
[    6.130000] [<80415e78>] mmc_rescan+0x428/0x4bc
[    6.130000] [<80043b98>] process_one_work+0x14c/0x38c
[    6.130000] [<80043f34>] worker_thread+0x15c/0x59c
[    6.130000] [<800493b4>] kthread+0xd0/0xe8
[    6.130000] [<80013b8c>] ret_from_kernel_thread+0x14/0x1c
[    6.130000] 
[    6.130000] 
[    6.130000] Code: 27bdffe0  2ca20001  afbf001c <00020336> 8f820014  24420001  af820014  3c02807d  8c42a184 
[    6.130000] ---[ end trace 0888e27679ed5f65 ]---
```
