### PR TITLE
Ci20 v3.18 bluetooth

### DIFF
--- a/Documentation/devicetree/bindings/net/rfkill/rfkill-relugator.txt
+++ b/Documentation/devicetree/bindings/net/rfkill/rfkill-relugator.txt
@@ -1,0 +1,28 @@
+Regulator consumer for rfkill devices
+
+Required properties:
+- compatible   : Must be "rfkill-regulator".
+- label  : Name of rfkill device.
+- type  : Type of rfkill device.
+
+Possible values (defined in include/dt-bindings/net/rfkill-regulator.h):
+	RFKILL_TYPE_ALL
+	RFKILL_TYPE_WLAN
+	RFKILL_TYPE_BLUETOOTH
+	RFKILL_TYPE_UWB
+	RFKILL_TYPE_WIMAX
+	RFKILL_TYPE_WWAN
+	RFKILL_TYPE_GPS
+	RFKILL_TYPE_FM
+	RFKILL_TYPE_NFC
+
+- vrfkill-supply - regulator device.
+
+Example:
+	gps-rfkill {
+		compatible = "rfkill-regulator";
+		label = "GPS";
+		type = <RFKILL_TYPE_GPS>;
+		vrfkill-supply = <&reg>;
+	};
+

--- a/arch/mips/boot/dts/ci20.dts
+++ b/arch/mips/boot/dts/ci20.dts
@@ -1,5 +1,6 @@
 /dts-v1/;
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/net/rfkill-regulator.h>
 #include "jz4780.dtsi"
 
 / {
@@ -69,7 +70,6 @@
 		regulator-name = "bt_reset_gpio";
 		gpio = <&gpf 8 0>;
 		enable-active-high;
-		regulator-always-on;
 	};
 
 	/* HACK: Keeping BT_reg_on high. No simple driver fix */
@@ -88,6 +88,13 @@
 		gpio = <&gpf 5 0>;
 		enable-active-high;
 		regulator-always-on;
+	};
+
+	bt-rfkill {
+		compatible = "rfkill-regulator";
+		label = "bt-reset";
+		type = <RFKILL_TYPE_BLUETOOTH>;
+		vrfkill-supply = <&bt_reset>;
 	};
 };
 

--- a/drivers/tty/serial/8250/8250_ingenic.c
+++ b/drivers/tty/serial/8250/8250_ingenic.c
@@ -132,9 +132,10 @@ EARLYCON_DECLARE(jz4780_uart, ingenic_early_console_setup);
 OF_EARLYCON_DECLARE(jz4780_uart, "ingenic,jz4780-uart",
 		    ingenic_early_console_setup);
 
+
 static void ingenic_uart_serial_out(struct uart_port *p, int offset, int value)
 {
-	int mcr, orig;
+	int ier;
 
 	switch (offset) {
 	case UART_FCR:
@@ -143,19 +144,21 @@ static void ingenic_uart_serial_out(struct uart_port *p, int offset, int value)
 		break;
 
 	case UART_IER:
+		/* Enable receive timeout interrupt with the 
+		 * receive line status interrupt */
+		value |= (value & 0x4) << 2;
+		break;
+		
+	case UART_MCR:
 		/* If we have enabled modem status IRQs we should enable modem
 		 * mode. */
-		mcr = orig = p->serial_in(p, UART_MCR);
-		if (value & UART_IER_MSI) {
-			mcr |= UART_MCR_MDCE | UART_MCR_FCM;
+		ier = p->serial_in(p, UART_IER);
+		
+		if (ier & UART_IER_MSI) {
+			value |= UART_MCR_MDCE | UART_MCR_FCM;
 		} else {
-			mcr &= ~(UART_MCR_MDCE | UART_MCR_FCM);
+			value &= ~(UART_MCR_MDCE | UART_MCR_FCM);
 		}
-
-		if (mcr != orig)
-			ingenic_uart_serial_out(p, UART_MCR, mcr);
-
-		value |= (value & 0x4) << 2;
 		break;
 
 	default:
@@ -163,6 +166,28 @@ static void ingenic_uart_serial_out(struct uart_port *p, int offset, int value)
 	}
 
 	writeb(value, p->membase + (offset << p->regshift));
+}
+
+static unsigned int ingenic_uart_serial_in(struct uart_port *p, int offset)
+{
+	unsigned int value;
+
+	value = readb(p->membase + (offset << p->regshift));
+	
+	/* Hide non-16550 compliant bits from higher levels */
+	switch (offset) {
+	case UART_FCR:
+		value &= ~UART_FCR_UME;
+		break;
+
+	case UART_MCR:
+		value &= ~(UART_MCR_MDCE | UART_MCR_FCM);
+		break;
+
+	default:
+		break;
+	}
+	return value;
 }
 
 static int ingenic_uart_probe(struct platform_device *pdev)
@@ -189,6 +214,7 @@ static int ingenic_uart_probe(struct platform_device *pdev)
 	uart.port.mapbase = regs->start;
 	uart.port.regshift = 2;
 	uart.port.serial_out = ingenic_uart_serial_out;
+	uart.port.serial_in = ingenic_uart_serial_in;
 	uart.port.irq = irq->start;
 	uart.port.dev = &pdev->dev;
 

--- a/include/dt-bindings/net/rfkill-regulator.h
+++ b/include/dt-bindings/net/rfkill-regulator.h
@@ -1,0 +1,23 @@
+/*
+ * This header provides macros for rfkill-regulator bindings.
+ *
+ * Copyright (C) 2014 Marek Belisko <marek@goldelico.com>
+ *
+ * GPLv2 only
+ */
+
+#ifndef __DT_BINDINGS_RFKILL_REGULATOR_H__
+#define __DT_BINDINGS_RFKILL_REGULATOR_H__
+
+
+#define RFKILL_TYPE_ALL		(0)
+#define RFKILL_TYPE_WLAN	(1)
+#define RFKILL_TYPE_BLUETOOTH	(2)
+#define RFKILL_TYPE_UWB		(3)
+#define RFKILL_TYPE_WIMAX	(4)
+#define RFKILL_TYPE_WWAN	(5)
+#define RFKILL_TYPE_GPS		(6)
+#define RFKILL_TYPE_FM		(7)
+#define RFKILL_TYPE_NFC		(8)
+
+#endif /* __DT_BINDINGS_RFKILL_REGULATOR_H__ */


### PR DESCRIPTION
Add RFKILL interface to reset the bluetooth module on CI20 boards. They are pretty tempremental and need resetting frequently!
Fix the hardware flow control implementation for the Ingenic JZ4780 Uarts.
