### PR TITLE
Ci20 v3.18 bluetooth v2

### DIFF
--- a/Documentation/devicetree/bindings/net/rfkill/rfkill-relugator.txt
+++ b/Documentation/devicetree/bindings/net/rfkill/rfkill-relugator.txt
@@ -1,0 +1,28 @@
+Regulator consumer for rfkill devices
+
+Required properties:
+- compatible   : Must be "rfkill-regulator".
+- label  : Name of rfkill device.
+- type  : Type of rfkill device.
+
+Possible values (defined in include/dt-bindings/net/rfkill-regulator.h):
+	RFKILL_TYPE_ALL
+	RFKILL_TYPE_WLAN
+	RFKILL_TYPE_BLUETOOTH
+	RFKILL_TYPE_UWB
+	RFKILL_TYPE_WIMAX
+	RFKILL_TYPE_WWAN
+	RFKILL_TYPE_GPS
+	RFKILL_TYPE_FM
+	RFKILL_TYPE_NFC
+
+- vrfkill-supply - regulator device.
+
+Example:
+	gps-rfkill {
+		compatible = "rfkill-regulator";
+		label = "GPS";
+		type = <RFKILL_TYPE_GPS>;
+		vrfkill-supply = <&reg>;
+	};
+

--- a/arch/mips/boot/dts/ci20.dts
+++ b/arch/mips/boot/dts/ci20.dts
@@ -1,5 +1,6 @@
 /dts-v1/;
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/net/rfkill-regulator.h>
 #include "jz4780.dtsi"
 
 / {
@@ -69,7 +70,6 @@
 		regulator-name = "bt_reset_gpio";
 		gpio = <&gpf 8 0>;
 		enable-active-high;
-		regulator-always-on;
 	};
 
 	/* HACK: Keeping BT_reg_on high. No simple driver fix */
@@ -88,6 +88,13 @@
 		gpio = <&gpf 5 0>;
 		enable-active-high;
 		regulator-always-on;
+	};
+
+	bt-rfkill {
+		compatible = "rfkill-regulator";
+		label = "bt-reset";
+		type = <RFKILL_TYPE_BLUETOOTH>;
+		vrfkill-supply = <&bt_reset>;
 	};
 };
 

--- a/include/dt-bindings/net/rfkill-regulator.h
+++ b/include/dt-bindings/net/rfkill-regulator.h
@@ -1,0 +1,23 @@
+/*
+ * This header provides macros for rfkill-regulator bindings.
+ *
+ * Copyright (C) 2014 Marek Belisko <marek@goldelico.com>
+ *
+ * GPLv2 only
+ */
+
+#ifndef __DT_BINDINGS_RFKILL_REGULATOR_H__
+#define __DT_BINDINGS_RFKILL_REGULATOR_H__
+
+
+#define RFKILL_TYPE_ALL		(0)
+#define RFKILL_TYPE_WLAN	(1)
+#define RFKILL_TYPE_BLUETOOTH	(2)
+#define RFKILL_TYPE_UWB		(3)
+#define RFKILL_TYPE_WIMAX	(4)
+#define RFKILL_TYPE_WWAN	(5)
+#define RFKILL_TYPE_GPS		(6)
+#define RFKILL_TYPE_FM		(7)
+#define RFKILL_TYPE_NFC		(8)
+
+#endif /* __DT_BINDINGS_RFKILL_REGULATOR_H__ */


### PR DESCRIPTION
Update the pull request to include fixes for the JZ4780 FIFO

These patches add an rfkill regulator to enable resetting the flaky bluetooth chip on the CI20.
Add the regulator to the CI20's DT.
Fix the hardware flow control in the UART driver
Fix the FIFO mode in the UART driver
