### PR TITLE
Use the new Ci20's LEDs to show CPU and NAND activity

### DIFF
--- a/arch/mips/boot/dts/ci20.dts
+++ b/arch/mips/boot/dts/ci20.dts
@@ -101,6 +101,22 @@
 		type = <RFKILL_TYPE_BLUETOOTH>;
 		vrfkill-supply = <&bt_reset>;
 	};
+
+	leds {
+		compatible = "gpio-leds";
+		led1 {
+			gpios = <&gpc 0 0>;
+			linux,default-trigger = "cpu0";
+		};
+		led2 {
+			gpios = <&gpc 1 0>;
+			linux,default-trigger = "cpu1";
+		};
+		led3 {
+			gpios = <&gpc 2 0>;
+			linux,default-trigger = "nand-disk";
+		};
+	};
 };
 
 &ext {

--- a/arch/mips/kernel/idle.c
+++ b/arch/mips/kernel/idle.c
@@ -14,6 +14,7 @@
 #include <linux/export.h>
 #include <linux/init.h>
 #include <linux/irqflags.h>
+#include <linux/leds.h>
 #include <linux/printk.h>
 #include <linux/sched.h>
 #include <asm/cpu.h>
@@ -259,10 +260,13 @@ void __init check_wait(void)
 
 void arch_cpu_idle(void)
 {
-	if (cpu_wait)
+	if (cpu_wait) {
+		ledtrig_cpu(CPU_LED_IDLE_START);
 		cpu_wait();
-	else
+		ledtrig_cpu(CPU_LED_IDLE_END);
+	} else {
 		local_irq_enable();
+	}
 }
 
 #ifdef CONFIG_CPU_IDLE


### PR DESCRIPTION
The new Ci20 has 4 LEDs, this PR makes two of them display CPU activity (one per core) and one to display NAND activity.

The change to `idle.c` is inspired by [ARM code](https://github.com/torvalds/linux/blob/master/arch/arm/kernel/process.c#L83).

**Note**: ci20_defconfig needs updating to include support for `gpio-leds` and the triggers used in this PR. I'll send a separate PR for that once #41 is merged.
