### PR TITLE
MIPS: Ci20: Change DT node for LED triggers to match silkscreen

### DIFF
--- a/arch/mips/boot/dts/ci20.dts
+++ b/arch/mips/boot/dts/ci20.dts
@@ -104,7 +104,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		led1 {
+		led3 {
 			gpios = <&gpc 0 0>;
 			linux,default-trigger = "cpu0";
 		};
@@ -112,7 +112,7 @@
 			gpios = <&gpc 1 0>;
 			linux,default-trigger = "cpu1";
 		};
-		led3 {
+		led1 {
 			gpios = <&gpc 2 0>;
 			linux,default-trigger = "nand-disk";
 		};


### PR DESCRIPTION
Next to the LEDs on the Ci20 is silkscreen lettering indicating the number
of each LED. The numbering in the DT node was the wrong way round, i.e
LED1 in the DT node was labelled as LED3 on the board.

Note: The LED labelling starts at LED0
