### PR TITLE
Ci20 v3.18 MSC0 Performance Fix

### DIFF
--- a/arch/mips/boot/dts/ci20.dts
+++ b/arch/mips/boot/dts/ci20.dts
@@ -125,7 +125,7 @@
 
 &msc0 {
 	bus-width = <4>;
-	max-frequency = <48000000>;
+	max-frequency = <50000000>;
 	cd-gpios = <&gpf 20 GPIO_ACTIVE_LOW>;
 
 	pinctrl-names = "default";

--- a/drivers/clk/jz47xx/jz4740-cgu.c
+++ b/drivers/clk/jz47xx/jz4740-cgu.c
@@ -94,51 +94,51 @@ static const struct jz47xx_cgu_clk_info jz4740_cgu_clocks[] = {
 	[JZ4740_CLK_PLL_HALF] = {
 		"pll half", CGU_CLK_DIV,
 		.parents = { JZ4740_CLK_PLL, -1 },
-		.div = { CGU_REG_CPCCR, 21, 1, -1, -1, -1 },
+		.div = { CGU_REG_CPCCR, 21, 0, 1, -1, -1, -1 },
 	},
 
 	[JZ4740_CLK_CCLK] = {
 		"cclk", CGU_CLK_DIV,
 		.parents = { JZ4740_CLK_PLL, -1 },
-		.div = { CGU_REG_CPCCR, 0, 4, 22, -1, -1 },
+		.div = { CGU_REG_CPCCR, 0, 0, 4, 22, -1, -1 },
 	},
 
 	[JZ4740_CLK_HCLK] = {
 		"hclk", CGU_CLK_DIV,
 		.parents = { JZ4740_CLK_PLL, -1 },
-		.div = { CGU_REG_CPCCR, 4, 4, 22, -1, -1 },
+		.div = { CGU_REG_CPCCR, 4, 0, 4, 22, -1, -1 },
 	},
 
 	[JZ4740_CLK_PCLK] = {
 		"pclk", CGU_CLK_DIV,
 		.parents = { JZ4740_CLK_PLL, -1 },
-		.div = { CGU_REG_CPCCR, 8, 4, 22, -1, -1 },
+		.div = { CGU_REG_CPCCR, 8, 0, 4, 22, -1, -1 },
 	},
 
 	[JZ4740_CLK_MCLK] = {
 		"mclk", CGU_CLK_DIV,
 		.parents = { JZ4740_CLK_PLL, -1 },
-		.div = { CGU_REG_CPCCR, 12, 4, 22, -1, -1 },
+		.div = { CGU_REG_CPCCR, 12, 0, 4, 22, -1, -1 },
 	},
 
 	[JZ4740_CLK_LCD] = {
 		"lcd", CGU_CLK_DIV | CGU_CLK_GATE,
 		.parents = { JZ4740_CLK_PLL_HALF, -1 },
-		.div = { CGU_REG_CPCCR, 16, 5, 22, -1, -1 },
+		.div = { CGU_REG_CPCCR, 16, 0, 5, 22, -1, -1 },
 		.gate_bit = 10,
 	},
 
 	[JZ4740_CLK_LCD_PCLK] = {
 		"lcd_pclk", CGU_CLK_DIV,
 		.parents = { JZ4740_CLK_PLL_HALF, -1 },
-		.div = { CGU_REG_LPCDR, 0, 11, -1, -1, -1 },
+		.div = { CGU_REG_LPCDR, 0, 0, 11, -1, -1, -1 },
 	},
 
 	[JZ4740_CLK_I2S] = {
 		"i2s", CGU_CLK_MUX | CGU_CLK_DIV | CGU_CLK_GATE,
 		.parents = { JZ4740_CLK_EXT, JZ4740_CLK_PLL_HALF, -1 },
 		.mux = { CGU_REG_CPCCR, 31, 1 },
-		.div = { CGU_REG_I2SCDR, 0, 8, -1, -1, -1 },
+		.div = { CGU_REG_I2SCDR, 0, 0, 8, -1, -1, -1 },
 		.gate_bit = 6,
 	},
 
@@ -146,21 +146,21 @@ static const struct jz47xx_cgu_clk_info jz4740_cgu_clocks[] = {
 		"spi", CGU_CLK_MUX | CGU_CLK_DIV | CGU_CLK_GATE,
 		.parents = { JZ4740_CLK_EXT, JZ4740_CLK_PLL, -1 },
 		.mux = { CGU_REG_SSICDR, 31, 1 },
-		.div = { CGU_REG_SSICDR, 0, 4, -1, -1, -1 },
+		.div = { CGU_REG_SSICDR, 0, 0, 4, -1, -1, -1 },
 		.gate_bit = 4,
 	},
 
 	[JZ4740_CLK_MMC] = {
 		"mmc", CGU_CLK_DIV | CGU_CLK_GATE,
 		.parents = { JZ4740_CLK_PLL_HALF, -1 },
-		.div = { CGU_REG_MSCCDR, 0, 5, -1, -1, -1 },
+		.div = { CGU_REG_MSCCDR, 0, 0, 5, -1, -1, -1 },
 		.gate_bit = 7,
 	},
 
 	[JZ4740_CLK_UHC] = {
 		"uhc", CGU_CLK_DIV | CGU_CLK_GATE,
 		.parents = { JZ4740_CLK_PLL_HALF, -1 },
-		.div = { CGU_REG_UHCCDR, 0, 4, -1, -1, -1 },
+		.div = { CGU_REG_UHCCDR, 0, 0, 4, -1, -1, -1 },
 		.gate_bit = 14,
 	},
 
@@ -168,7 +168,7 @@ static const struct jz47xx_cgu_clk_info jz4740_cgu_clocks[] = {
 		"udc", CGU_CLK_MUX | CGU_CLK_DIV,
 		.parents = { JZ4740_CLK_EXT, JZ4740_CLK_PLL_HALF, -1 },
 		.mux = { CGU_REG_CPCCR, 29, 1 },
-		.div = { CGU_REG_CPCCR, 23, 6, -1, -1, -1 },
+		.div = { CGU_REG_CPCCR, 23, 0, 6, -1, -1, -1 },
 		/* TODO: gate via SCR */
 	},
 

--- a/drivers/clk/jz47xx/jz4780-cgu.c
+++ b/drivers/clk/jz47xx/jz4780-cgu.c
@@ -228,13 +228,13 @@ static const struct jz47xx_cgu_clk_info jz4780_cgu_clocks[] = {
 	[JZ4780_CLK_CPU] = {
 		"cpu", CGU_CLK_DIV,
 		.parents = { JZ4780_CLK_CPUMUX, -1 },
-		.div = { CGU_REG_CLOCKCONTROL, 0, 4, 22, -1, -1 },
+		.div = { CGU_REG_CLOCKCONTROL, 0, 0, 4, 22, -1, -1 },
 	},
 
 	[JZ4780_CLK_L2CACHE] = {
 		"l2cache", CGU_CLK_DIV,
 		.parents = { JZ4780_CLK_CPUMUX, -1 },
-		.div = { CGU_REG_CLOCKCONTROL, 4, 4, -1, -1, -1 },
+		.div = { CGU_REG_CLOCKCONTROL, 4, 0, 4, -1, -1, -1 },
 	},
 
 	[JZ4780_CLK_AHB0] = {
@@ -242,7 +242,7 @@ static const struct jz47xx_cgu_clk_info jz4780_cgu_clocks[] = {
 		.parents = { -1, JZ4780_CLK_SCLKA, JZ4780_CLK_MPLL,
 			     JZ4780_CLK_EPLL },
 		.mux = { CGU_REG_CLOCKCONTROL, 26, 2 },
-		.div = { CGU_REG_CLOCKCONTROL, 8, 4, 21, -1, -1 },
+		.div = { CGU_REG_CLOCKCONTROL, 8, 0, 4, 21, -1, -1 },
 	},
 
 	[JZ4780_CLK_AHB2PMUX] = {
@@ -255,20 +255,20 @@ static const struct jz47xx_cgu_clk_info jz4780_cgu_clocks[] = {
 	[JZ4780_CLK_AHB2] = {
 		"ahb2", CGU_CLK_DIV,
 		.parents = { JZ4780_CLK_AHB2PMUX, -1 },
-		.div = { CGU_REG_CLOCKCONTROL, 12, 4, 20, -1, -1 },
+		.div = { CGU_REG_CLOCKCONTROL, 12, 0, 4, 20, -1, -1 },
 	},
 
 	[JZ4780_CLK_PCLK] = {
 		"pclk", CGU_CLK_DIV,
 		.parents = { JZ4780_CLK_AHB2PMUX, -1 },
-		.div = { CGU_REG_CLOCKCONTROL, 16, 4, 20, -1, -1 },
+		.div = { CGU_REG_CLOCKCONTROL, 16, 0, 4, 20, -1, -1 },
 	},
 
 	[JZ4780_CLK_DDR] = {
 		"ddr", CGU_CLK_MUX | CGU_CLK_DIV,
 		.parents = { -1, JZ4780_CLK_SCLKA, JZ4780_CLK_MPLL, -1 },
 		.mux = { CGU_REG_DDRCDR, 30, 2 },
-		.div = { CGU_REG_DDRCDR, 0, 4, 29, 28, 27 },
+		.div = { CGU_REG_DDRCDR, 0, 0, 4, 29, 28, 27 },
 	},
 
 	[JZ4780_CLK_VPU] = {
@@ -276,7 +276,7 @@ static const struct jz47xx_cgu_clk_info jz4780_cgu_clocks[] = {
 		.parents = { JZ4780_CLK_SCLKA, JZ4780_CLK_MPLL,
 			     JZ4780_CLK_EPLL, -1 },
 		.mux = { CGU_REG_VPUCDR, 30, 2 },
-		.div = { CGU_REG_VPUCDR, 0, 4, 29, 28, 27 },
+		.div = { CGU_REG_VPUCDR, 0, 0, 4, 29, 28, 27 },
 		.gate_bit = 32 + 2,
 	},
 
@@ -284,7 +284,7 @@ static const struct jz47xx_cgu_clk_info jz4780_cgu_clocks[] = {
 		"i2s_pll", CGU_CLK_MUX | CGU_CLK_DIV,
 		.parents = { JZ4780_CLK_SCLKA, JZ4780_CLK_EPLL, -1 },
 		.mux = { CGU_REG_I2SCDR, 30, 1 },
-		.div = { CGU_REG_I2SCDR, 0, 8, 29, 28, 27 },
+		.div = { CGU_REG_I2SCDR, 0, 0, 8, 29, 28, 27 },
 	},
 
 	[JZ4780_CLK_I2S] = {
@@ -298,7 +298,7 @@ static const struct jz47xx_cgu_clk_info jz4780_cgu_clocks[] = {
 		.parents = { JZ4780_CLK_SCLKA, JZ4780_CLK_MPLL,
 			     JZ4780_CLK_VPLL, -1 },
 		.mux = { CGU_REG_LP0CDR, 30, 2 },
-		.div = { CGU_REG_LP0CDR, 0, 8, 28, 27, 26 },
+		.div = { CGU_REG_LP0CDR, 0, 0, 8, 28, 27, 26 },
 	},
 
 	[JZ4780_CLK_LCD1PIXCLK] = {
@@ -306,7 +306,7 @@ static const struct jz47xx_cgu_clk_info jz4780_cgu_clocks[] = {
 		.parents = { JZ4780_CLK_SCLKA, JZ4780_CLK_MPLL,
 			     JZ4780_CLK_VPLL, -1 },
 		.mux = { CGU_REG_LP1CDR, 30, 2 },
-		.div = { CGU_REG_LP1CDR, 0, 8, 28, 27, 26 },
+		.div = { CGU_REG_LP1CDR, 0, 0, 8, 28, 27, 26 },
 	},
 
 	[JZ4780_CLK_MSCMUX] = {
@@ -318,21 +318,21 @@ static const struct jz47xx_cgu_clk_info jz4780_cgu_clocks[] = {
 	[JZ4780_CLK_MSC0] = {
 		"msc0", CGU_CLK_DIV | CGU_CLK_GATE,
 		.parents = { JZ4780_CLK_MSCMUX, -1 },
-		.div = { CGU_REG_MSC0CDR, 0, 8, 29, 28, 27 },
+		.div = { CGU_REG_MSC0CDR, 0, 1, 8, 29, 28, 27 },
 		.gate_bit = 3,
 	},
 
 	[JZ4780_CLK_MSC1] = {
 		"msc1", CGU_CLK_DIV | CGU_CLK_GATE,
 		.parents = { JZ4780_CLK_MSCMUX, -1 },
-		.div = { CGU_REG_MSC1CDR, 0, 8, 29, 28, 27 },
+		.div = { CGU_REG_MSC1CDR, 0, 1, 8, 29, 28, 27 },
 		.gate_bit = 11,
 	},
 
 	[JZ4780_CLK_MSC2] = {
 		"msc2", CGU_CLK_DIV | CGU_CLK_GATE,
 		.parents = { JZ4780_CLK_MSCMUX, -1 },
-		.div = { CGU_REG_MSC2CDR, 0, 8, 29, 28, 27 },
+		.div = { CGU_REG_MSC2CDR, 0, 1, 8, 29, 28, 27 },
 		.gate_bit = 12,
 	},
 
@@ -341,7 +341,7 @@ static const struct jz47xx_cgu_clk_info jz4780_cgu_clocks[] = {
 		.parents = { JZ4780_CLK_SCLKA, JZ4780_CLK_MPLL,
 			     JZ4780_CLK_EPLL, JZ4780_CLK_OTGPHY },
 		.mux = { CGU_REG_UHCCDR, 30, 2 },
-		.div = { CGU_REG_UHCCDR, 0, 8, 29, 28, 27 },
+		.div = { CGU_REG_UHCCDR, 0, 0, 8, 29, 28, 27 },
 		.gate_bit = 24,
 	},
 
@@ -349,7 +349,7 @@ static const struct jz47xx_cgu_clk_info jz4780_cgu_clocks[] = {
 		"ssi_pll", CGU_CLK_MUX | CGU_CLK_DIV,
 		.parents = { JZ4780_CLK_SCLKA, JZ4780_CLK_MPLL, -1 },
 		.mux = { CGU_REG_SSICDR, 30, 1 },
-		.div = { CGU_REG_SSICDR, 0, 8, 29, 28, 27 },
+		.div = { CGU_REG_SSICDR, 0, 0, 8, 29, 28, 27 },
 	},
 
 	[JZ4780_CLK_SSI] = {
@@ -362,7 +362,7 @@ static const struct jz47xx_cgu_clk_info jz4780_cgu_clocks[] = {
 		"cim_mclk", CGU_CLK_MUX | CGU_CLK_DIV,
 		.parents = { JZ4780_CLK_SCLKA, JZ4780_CLK_MPLL, -1 },
 		.mux = { CGU_REG_CIMCDR, 31, 1 },
-		.div = { CGU_REG_CIMCDR, 0, 8, 30, 29, 28 },
+		.div = { CGU_REG_CIMCDR, 0, 0, 8, 30, 29, 28 },
 	},
 
 	[JZ4780_CLK_PCMPLL] = {
@@ -370,7 +370,7 @@ static const struct jz47xx_cgu_clk_info jz4780_cgu_clocks[] = {
 		.parents = { JZ4780_CLK_SCLKA, JZ4780_CLK_MPLL,
 			     JZ4780_CLK_EPLL, JZ4780_CLK_VPLL },
 		.mux = { CGU_REG_PCMCDR, 29, 2 },
-		.div = { CGU_REG_PCMCDR, 0, 8, 28, 27, 26 },
+		.div = { CGU_REG_PCMCDR, 0, 0, 8, 28, 27, 26 },
 	},
 
 	[JZ4780_CLK_PCM] = {
@@ -385,7 +385,7 @@ static const struct jz47xx_cgu_clk_info jz4780_cgu_clocks[] = {
 		.parents = { -1, JZ4780_CLK_SCLKA, JZ4780_CLK_MPLL,
 			     JZ4780_CLK_EPLL },
 		.mux = { CGU_REG_GPUCDR, 30, 2 },
-		.div = { CGU_REG_GPUCDR, 0, 4, 29, 28, 27 },
+		.div = { CGU_REG_GPUCDR, 0, 0, 4, 29, 28, 27 },
 		.gate_bit = 32 + 4,
 	},
 
@@ -394,7 +394,7 @@ static const struct jz47xx_cgu_clk_info jz4780_cgu_clocks[] = {
 		.parents = { JZ4780_CLK_SCLKA, JZ4780_CLK_MPLL,
 			     JZ4780_CLK_VPLL, -1 },
 		.mux = { CGU_REG_HDMICDR, 30, 2 },
-		.div = { CGU_REG_HDMICDR, 0, 8, 29, 28, 26 },
+		.div = { CGU_REG_HDMICDR, 0, 0, 8, 29, 28, 26 },
 		.gate_bit = 32 + 9,
 	},
 
@@ -403,7 +403,7 @@ static const struct jz47xx_cgu_clk_info jz4780_cgu_clocks[] = {
 		.parents = { -1, JZ4780_CLK_SCLKA, JZ4780_CLK_MPLL,
 			     JZ4780_CLK_EPLL },
 		.mux = { CGU_REG_BCHCDR, 30, 2 },
-		.div = { CGU_REG_BCHCDR, 0, 4, 29, 28, 27 },
+		.div = { CGU_REG_BCHCDR, 0, 0, 4, 29, 28, 27 },
 		.gate_bit = 1,
 	},
 

--- a/drivers/clk/jz47xx/jz47xx-cgu.h
+++ b/drivers/clk/jz47xx/jz47xx-cgu.h
@@ -80,8 +80,11 @@ struct jz47xx_cgu_mux_info {
 /**
  * struct jz47xx_cgu_div_info - information about a divider
  * @reg: offset of the divider control register within the CGU
- * @shift: number of bits to shift the divide value by (ie. the index of
+ * @shift: number of bits to left shift the divide value by (ie. the index of
  *         the lowest bit of the divide value within its control register)
+ * @div: number of bits to right shift the divide value by (ie. for if the
+ *	 effective divider value is the value written to the register
+ *	 multiplied by some constant).
  * @bits: the size of the divide value in bits
  * @ce_bit: the index of the change enable bit within reg, or -1 is there
  *          isn't one
@@ -91,6 +94,7 @@ struct jz47xx_cgu_mux_info {
 struct jz47xx_cgu_div_info {
 	unsigned reg;
 	unsigned shift:5;
+	unsigned div:5;
 	unsigned bits:5;
 	int ce_bit:6;
 	int busy_bit:6;


### PR DESCRIPTION
With the move from 3.0.8 to 3.18 the MMC performance has decreased significantly. This PR addresses this by correctly setting the MSC clocks.

A quick `dd` shows the following:

Before:

```
root@ci20:~# dd if=/mnt/sd/test.bin of=/mnt/tmpfs/test.bin bs=4096

32768+0 records in

32768+0 records out

134217728 bytes (134 MB) copied, 12.0821 s, 11.1 MB/s


root@ci20:~# echo 3 > /proc/sys/vm/drop_caches

[  117.210000] bash (606): drop_caches: 3


root@ci20:~# dd if=/mnt/tmpfs/test.bin of=/mnt/sd/test.bin bs=4096

32768+0 records in

32768+0 records out

134217728 bytes (134 MB) copied, 10.9081 s, 12.3 MB/s
```

After:

```
root@ci20:~# dd if=/mnt/sd/test.bin of=/mnt/tmpfs/test.bin bs=4096

32768+0 records in

32768+0 records out
134217728 bytes (134 MB) copied, 6.38894 s, 21.0 MB/s


root@ci20:~# echo 3 > /proc/sys/vm/drop_caches

[  292.870000] bash (574): drop_caches: 3


root@ci20:~# dd if=/mnt/tmpfs/test.bin of=/mnt/sd/test.bin bs=4096

32768+0 records in

32768+0 records out

134217728 bytes (134 MB) copied, 7.10854 s, 18.9 MB/s
```
