### PR TITLE
Ci20 v3.18 audio fixup

### DIFF
--- a/sound/soc/codecs/jz4780.c
+++ b/sound/soc/codecs/jz4780.c
@@ -242,6 +242,8 @@ static const struct snd_soc_dapm_widget jz4780_codec_dapm_widgets[] = {
 	SND_SOC_DAPM_INPUT("AIP2"),
 	SND_SOC_DAPM_INPUT("AIP3"),
 
+	SND_SOC_DAPM_OUTPUT("SYSCLK"),
+
 	SND_SOC_DAPM_OUTPUT("AOHPL"),
 	SND_SOC_DAPM_OUTPUT("AOHPR"),
 };
@@ -258,6 +260,12 @@ static const struct snd_soc_dapm_route jz4780_codec_dapm_routes[] = {
 
 	{"AOHPL", NULL, "Output Mixer"},
 	{"AOHPR", NULL, "Output Mixer"},
+
+	/* SYSCLK output from the codec to the AIC is required to keep the
+	 * DMA transfer going during playback when all audible outputs have
+	 * been disabled.
+	 */
+	{"SYSCLK", NULL, "DAC" },
 };
 
 static int jz4780_codec_hw_params(struct snd_pcm_substream *substream,

--- a/sound/soc/jz4780/ci20.c
+++ b/sound/soc/jz4780/ci20.c
@@ -245,14 +245,14 @@ static int ingenic_asoc_ci20_probe(struct platform_device *pdev)
 		ci20_dai_link[0].codec_name = NULL;
 	}
 
-	ret = gpio_request(GPIO_HP_MUTE, "Headphone Mute");
+	ret = devm_gpio_request(&pdev->dev, GPIO_HP_MUTE, "Headphone Mute");
 	if (ret < 0)
 		dev_warn(&pdev->dev, "Failed to request mute GPIO: %d\n",
 			 ret);
 
 	gpio_direction_output(GPIO_HP_MUTE, 1);
 
-	ret = gpio_request(GPIO_MIC_SW_EN, "Mic Switch Enable");
+	ret = devm_gpio_request(&pdev->dev, GPIO_MIC_SW_EN, "Mic Switch Enable");
 	if (ret < 0)
 		dev_warn(&pdev->dev,
 			 "Failed to request mic switch enable GPIO: %d\n",
@@ -273,8 +273,6 @@ static int ingenic_asoc_ci20_remove(struct platform_device *pdev)
 
 	snd_soc_unregister_card(card);
 	snd_soc_jack_free_gpios(&ci20_hp_jack, 1, &ci20_hp_jack_gpio);
-	gpio_free(GPIO_MIC_SW_EN);
-	gpio_free(GPIO_HP_MUTE);
 
 	return 0;
 }


### PR DESCRIPTION
These commits fix the GPIO related error during bootup, and allow audio to play when no headphones are inserted.
