### PR TITLE
serial: jz_uart: Reenable sysrq trigger support

### DIFF
--- a/drivers/tty/serial/jz_uart.c
+++ b/drivers/tty/serial/jz_uart.c
@@ -280,10 +280,10 @@ static inline void receive_chars(unsigned long data, unsigned int status)
 			else if (status & UART_LSR_FE)
 				flag = TTY_FRAME;
 		}
-/*
+
 		if (uart_handle_sysrq_char(&up->port, ch))
 			goto ignore_char;
-*/
+
 		uart_insert_char(&up->port, status, UART_LSR_OE, ch, flag);
 
 ignore_char:


### PR DESCRIPTION
Without this PR, trying to start KDB over serial won't work as the character following the `BREAK` will be treated as a normal character.

There was no mention in Ingenic's kernel as to why they disabled this, but I have uncommented it and it works fine....
