### PR TITLE
Fix SMP bootstrap code

### DIFF
--- a/arch/mips/jz4740/smp-entry.S
+++ b/arch/mips/jz4740/smp-entry.S
@@ -66,7 +66,8 @@ LEAF(jz4780_secondary_cpu_entry)
 	la	t0, jz4780_cpu_entry_gp
 	lw	gp, 0(t0)
 
-	/* off we go! */
-	j	smp_bootstrap
+	/* jump to the kernel in kseg0 */
+	la	t0, smp_bootstrap
+	jr	t0
 	 nop
 	END(jz4780_secondary_cpu_entry)

--- a/arch/mips/jz4740/smp.c
+++ b/arch/mips/jz4740/smp.c
@@ -22,7 +22,6 @@
 
 #include <linux/clk.h>
 #include <linux/clockchips.h>
-#include <linux/delay.h>
 #include <linux/interrupt.h>
 #include <linux/of.h>
 #include <linux/sched.h>
@@ -272,12 +271,4 @@ static struct plat_smp_ops jz4780_smp_ops = {
 void jz4780_smp_init(void)
 {
 	register_smp_ops(&jz4780_smp_ops);
-}
-
-unsigned long calibrate_delay_is_known(void)
-{
-	if (smp_processor_id() == 0)
-		return 0;
-
-	return loops_per_jiffy;
 }


### PR DESCRIPTION
Fix to SMP bootstrap code so that kernel is executed from KSEG0 instead of KSEG1, which fixes calibration of the delay loop and slowness in the idle task on the second core.
