### PR TITLE
Reduce overhead of idle on SMP

### DIFF
--- a/arch/mips/include/asm/mach-jz4740/jz4780-smp.h
+++ b/arch/mips/include/asm/mach-jz4740/jz4780-smp.h
@@ -86,9 +86,10 @@
 
 #ifdef CONFIG_SMP
 
+extern void jz4780_smp_wait_irqoff(void);
+
 extern void jz4780_smp_init(void);
 extern void jz4780_secondary_cpu_entry(void);
-extern void jz4780_smp_irq(void);
 
 #else /* !CONFIG_SMP */
 


### PR DESCRIPTION
With SMP, the JZ4780 requires dirty dcache lines to be written back before a core executes a wait instruction, as wait will gate the core clock, and if another core tries to access a cache line from a waiting core's cache, it will lock up.

This is currently solved by doing a writeback/invalidate on the whole data cache before executing a wait, however doing so has a significant performance cost, particularly on workloads that involve tasks across cores waking each other up back and forth. A userland test case involving 2 tasks waking each other up back and forth on semaphores performs 500k iterations in ~6s without SMP, yet takes ~26s with SMP.

This patch greatly reduces this overhead by instead only doing a writeback/invalidate on cache lines which are marked dirty. There is still some overhead to this, so in addition a check is also added to see if there is a pending interrupt (such as a SMP reschedule IPI) just before peforming the cache flush to avoid performing it and waiting if there is. This gives a small improvement as well.

The overall result is a large performance improvement on SMP:
- Semaphore test case: ~26s -> ~9s
- SGX + glxgears: ~240fps -> ~410fps
- Wi-Fi + iperf: ~8Mbit/s -> ~20Mbit/s
