### PR TITLE
mfd: jz4740-adc: Init mask cache in generic IRQ chip

### DIFF
--- a/drivers/mfd/jz4740-adc.c
+++ b/drivers/mfd/jz4740-adc.c
@@ -276,7 +276,8 @@ static int jz4740_adc_probe(struct platform_device *pdev)
 	ct->chip.irq_unmask = irq_gc_mask_clr_bit;
 	ct->chip.irq_ack = irq_gc_ack_set_bit;
 
-	irq_setup_generic_chip(gc, IRQ_MSK(5), 0, 0, IRQ_NOPROBE | IRQ_LEVEL);
+	irq_setup_generic_chip(gc, IRQ_MSK(5), IRQ_GC_INIT_MASK_CACHE, 0,
+				IRQ_NOPROBE | IRQ_LEVEL);
 
 	adc->gc = gc;
 


### PR DESCRIPTION
The mask cache must be initialised in the generic IRQ chip,
otherwise enabling one channel will actually enable all
channels when the empty mask cache is written.

This fixes a bug which manifests on some V1 Ci20 boards 
as a stall when the hwmon driver was probed

Signed-off-by: Matt Redfearn matt.redfearn@imgtec.com
