### PR TITLE
sound: soc: ci20: Dont print error message on probe defer

### DIFF
--- a/sound/soc/jz4780/ci20.c
+++ b/sound/soc/jz4780/ci20.c
@@ -261,7 +261,7 @@ static int ingenic_asoc_ci20_probe(struct platform_device *pdev)
 	gpio_direction_output(GPIO_MIC_SW_EN, 0);
 
 	ret = snd_soc_register_card(card);
-	if (ret)
+	if ((ret) && (ret != -EPROBE_DEFER))
 		dev_err(&pdev->dev, "snd_soc_register_card() failed:%d\n", ret);
 
 	return ret;


### PR DESCRIPTION
This driver always fails to insert the first time as the HDMI
sink has not yet been probed, so don't print an error about it

Signed-off-by: Matt Redfearn matt.redfearn@imgtec.com
