### PR TITLE
mips: Ci20: Add pinctrl to UART DT nodes

### DIFF
--- a/arch/mips/boot/dts/ci20.dts
+++ b/arch/mips/boot/dts/ci20.dts
@@ -238,6 +238,31 @@
 	};
 };
 
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pins_uart0_data>;
+};
+
+&uart1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pins_uart1_data>;
+};
+
+&uart2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pins_uart2_dataplusflow>;
+};
+
+&uart3 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pins_uart3_data>;
+};
+
+&uart4 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pins_uart4_data>;
+};
+
 &i2c0 {
 	clock-frequency = <100000>;
 	pinctrl-names = "default";

--- a/arch/mips/boot/dts/jz4780.dtsi
+++ b/arch/mips/boot/dts/jz4780.dtsi
@@ -233,6 +233,20 @@
 				};
 			};
 
+			pinfunc_uart1: uart1 {
+				pins_uart1_data: uart1-data {
+					ingenic,pins = <&gpd  26 0 &pincfg_pull_up  /* rxd */
+							&gpd  28 0 &pincfg_nobias>; /* txd */
+				};
+
+				pins_uart1_dataplusflow: uart1-dataplusflow {
+					ingenic,pins = <&gpd  26 0 &pincfg_pull_up  /* rxd */
+							&gpd  27 0 &pincfg_nobias   /* cts */
+							&gpd  29 0 &pincfg_nobias   /* rts */
+							&gpd  28 0 &pincfg_nobias>; /* txd */
+				};
+			};
+
 			pinfunc_uart2: uart2 {
 				pins_uart2_data: uart2-data {
 					ingenic,pins = <&gpd  6 1 &pincfg_nobias  /* rxd */
@@ -467,8 +481,6 @@
 			interrupt-parent = <&intc>;
 			interrupts = <49>;
 
-			pinctrl-names = "default";
-			pinctrl-0 = <&pins_uart2_dataplusflow>;
 			clocks = <&ext>, <&cgu JZ4780_CLK_UART2>;
 			clock-names = "baud", "module";
 		};


### PR DESCRIPTION
The UART DT nodes were missing their relevant pinctrl
information and UART 1 had no pinctrl information - fix this.
Also, move Ci20 specific UART pinctrl options to ci20.dts.

Signed-off-by: Harvey Hunt harvey.hunt@imgtec.com
