### PR TITLE
add patch for gcc5 asm compile error

### DIFF
--- a/lib/mpi/longlong.h
+++ b/lib/mpi/longlong.h
@@ -639,7 +639,7 @@ do { \
 	**************  MIPS  *****************
 	***************************************/
 #if defined(__mips__) && W_TYPE_SIZE == 32
-#if __GNUC__ >= 4 && __GNUC_MINOR__ >= 4
+#if (__GNUC__ >= 5) || (__GNUC__ >= 4 && __GNUC_MINOR__ >= 4)
 #define umul_ppmm(w1, w0, u, v)			\
 do {						\
 	UDItype __ll = (UDItype)(u) * (v);	\
@@ -671,7 +671,7 @@ do {						\
 	**************  MIPS/64  **************
 	***************************************/
 #if (defined(__mips) && __mips >= 3) && W_TYPE_SIZE == 64
-#if __GNUC__ >= 4 && __GNUC_MINOR__ >= 4
+#if (__GNUC__ >= 5) || (__GNUC__ >= 4 && __GNUC_MINOR__ >= 4)
 #define umul_ppmm(w1, w0, u, v) \
 do {									\
 	typedef unsigned int __ll_UTItype __attribute__((mode(TI)));	\


### PR DESCRIPTION
Needed this for new crossdev toolchain, plucked from upstream:

 crossdev version:      2cdf8714b2d575d6e1554b6ed397451b153ae76c
 Host Portage ARCH:     amd64
 Target Portage ARCH:   mips
 Target System:         mipsel-unknown-linux-gnu
 Stage:                 4 (C/C++ compiler)
 ABIs:                  o32

 binutils:              binutils-2.25.1-r1
 gcc:                   gcc-5.3.0
 headers:               linux-headers-3.18
 libc:                  glibc-2.22-r1

 CROSSDEV_OVERLAY:      /usr/local/mipsel-cross
 PORT_LOGDIR:           /var/log/portage
 PORTAGE_CONFIGROOT:  
 Portage flags:          -v -b
